### PR TITLE
商品削除機能の編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,6 +40,12 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
   
   private
 
@@ -52,6 +58,7 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
+    @item = Item.find(params[:id])
     unless @item.user.id == current_user.id
           # 投稿者専用ページ == 投稿者(ログインユーザー)
           # 投稿者(ログインユーザー)が投稿者専用ページではないページに遷移しようとした時は

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   root to: "items#index"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :items
-  resources :items, only: [:new, :create, :show, :edit, :update]
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# what
商品削除機能の編集
# why
商品削除機能の実装のため

・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/a5b6354cdda4d5123184293f390ec510
